### PR TITLE
修改LPDSliderView继承UIControl

### DIFF
--- a/LPDControlsKit/Classes/LPDSliderView.h
+++ b/LPDControlsKit/Classes/LPDSliderView.h
@@ -22,7 +22,7 @@
 
 @end
 
-@interface LPDSliderView : UIView
+@interface LPDSliderView : UIControl
 
 @property (nonatomic, strong) UILabel *label;
 @property (nonatomic, weak) id <LPDSliderViewDelegate> delegate;

--- a/LPDControlsKit/Classes/LPDSliderView.m
+++ b/LPDControlsKit/Classes/LPDSliderView.m
@@ -36,6 +36,12 @@
     return self;
 }
 
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    _label.frame = CGRectMake(44, kBorderWidth, self.frame.size.width-44, self.frame.size.height);
+}
+
+
 -(void)initSlider {
     self.foregroundView = [[UIView alloc] init];
     self.handleView = [[UIImageView alloc] init];
@@ -91,15 +97,18 @@ static float handleViewLeft = 0.0f;
             CGRect frame = CGRectMake(0, kBorderWidth, self.handleView.frame.size.width, self.handleView.frame.size.height);
             if (self.handleView.frame.origin.x + self.handleView.frame.size.width > 0.8 * self.frame.size.width) {
                 frame = CGRectMake(self.frame.size.width - self.handleView.frame.size.width, kBorderWidth, self.handleView.frame.size.width, self.handleView.frame.size.height);
-                [self setValue:1.0 withAnimation:NO completion:nil];
+                self.value = 1.0;
+                //                [self setValue:1.0 withAnimation:NO completion:nil];
             }else{
-                [self setValue:0.0 withAnimation:NO completion:nil];
+                //                [self setValue:0.0 withAnimation:NO completion:nil];
+                self.value = 0.0;
             }
             __weak __typeof(self)weakSelf = self;
             [UIView animateWithDuration:kAnimationSpeed animations:^ {
                 weakSelf.handleView.frame = frame;
-                weakSelf.foregroundView.frame = CGRectMake(0, 0, self.handleView.frame.origin.x + self.handleView.frame.size.width/2, self.frame.size.height);
+                weakSelf.foregroundView.frame = CGRectMake(0, kBorderWidth, self.handleView.frame.origin.x + self.handleView.frame.size.width/2, self.frame.size.height);
             } completion:^(BOOL finished) {
+                NSLog(@"===================end===========");
                 if (weakSelf.delegate && [weakSelf.delegate respondsToSelector:@selector(sliderValueChangeEnded:)]) {
                     [weakSelf.delegate sliderValueChangeEnded:weakSelf];
                 }
@@ -157,6 +166,7 @@ static float handleViewLeft = 0.0f;
 -(void)setHandleImage:(UIImage *)handleImage{
     _handleImage = handleImage;
     _handleView.image = handleImage;
+    _handleView.contentMode = UIViewContentModeCenter;
     [_handleView sizeToFit];
     [self setValue:0.0 withAnimation:NO completion:nil];
 }
@@ -185,7 +195,7 @@ static float handleViewLeft = 0.0f;
     }
     
     self.value = p.x / self.frame.size.width;
-    self.foregroundView.frame = CGRectMake(0, 0, p.x, self.frame.size.height);
+    self.foregroundView.frame = CGRectMake(0, kBorderWidth, p.x, self.frame.size.height);
     
     if (self.foregroundView.frame.size.width <= 0) {
         self.handleView.frame = CGRectMake(0, kBorderWidth, self.handleWidth, self.foregroundView.frame.size.height-kBorderWidth);

--- a/LPDControlsKit/Classes/LPDSliderView.m
+++ b/LPDControlsKit/Classes/LPDSliderView.m
@@ -38,7 +38,7 @@
 
 - (void)layoutSubviews {
     [super layoutSubviews];
-    _label.frame = CGRectMake(44, kBorderWidth, self.frame.size.width-44, self.frame.size.height);
+    _label.frame = CGRectMake(44, 0, self.frame.size.width-44, self.frame.size.height);
 }
 
 
@@ -83,8 +83,8 @@ static float handleViewLeft = 0.0f;
             self.value = (pointX + self.handleView.frame.size.width)/self.frame.size.width;
             __weak __typeof(self)weakSelf = self;
             [UIView animateWithDuration:kAnimationSpeed animations:^ {
-                weakSelf.handleView.frame = CGRectMake(pointX, kBorderWidth, self.handleView.frame.size.width, self.handleView.frame.size.height);
-                weakSelf.foregroundView.frame = CGRectMake(0, kBorderWidth, self.handleView.frame.origin.x+self.handleView.frame.size.width/2, self.frame.size.height);
+                weakSelf.handleView.frame = CGRectMake(pointX, 0, self.handleView.frame.size.width, self.handleView.frame.size.height);
+                weakSelf.foregroundView.frame = CGRectMake(0, 0, self.handleView.frame.origin.x+self.handleView.frame.size.width/2, self.frame.size.height);
             } completion:^(BOOL finished) {
                 if (weakSelf.delegate && [weakSelf.delegate respondsToSelector:@selector(sliderValueChanged:)]) {
                     [weakSelf.delegate sliderValueChanged:weakSelf];
@@ -94,9 +94,9 @@ static float handleViewLeft = 0.0f;
         }
         case UIGestureRecognizerStateEnded:
         {
-            CGRect frame = CGRectMake(0, kBorderWidth, self.handleView.frame.size.width, self.handleView.frame.size.height);
+            CGRect frame = CGRectMake(0, 0, self.handleView.frame.size.width, self.handleView.frame.size.height);
             if (self.handleView.frame.origin.x + self.handleView.frame.size.width > 0.8 * self.frame.size.width) {
-                frame = CGRectMake(self.frame.size.width - self.handleView.frame.size.width, kBorderWidth, self.handleView.frame.size.width, self.handleView.frame.size.height);
+                frame = CGRectMake(self.frame.size.width - self.handleView.frame.size.width, 0, self.handleView.frame.size.width, self.handleView.frame.size.height);
                 self.value = 1.0;
                 //                [self setValue:1.0 withAnimation:NO completion:nil];
             }else{
@@ -106,7 +106,7 @@ static float handleViewLeft = 0.0f;
             __weak __typeof(self)weakSelf = self;
             [UIView animateWithDuration:kAnimationSpeed animations:^ {
                 weakSelf.handleView.frame = frame;
-                weakSelf.foregroundView.frame = CGRectMake(0, kBorderWidth, self.handleView.frame.origin.x + self.handleView.frame.size.width/2, self.frame.size.height);
+                weakSelf.foregroundView.frame = CGRectMake(0, 0, self.handleView.frame.origin.x + self.handleView.frame.size.width/2, self.frame.size.height);
             } completion:^(BOOL finished) {
                 NSLog(@"===================end===========");
                 if (weakSelf.delegate && [weakSelf.delegate respondsToSelector:@selector(sliderValueChangeEnded:)]) {
@@ -167,6 +167,7 @@ static float handleViewLeft = 0.0f;
     _handleImage = handleImage;
     _handleView.image = handleImage;
     _handleView.contentMode = UIViewContentModeCenter;
+    
     [_handleView sizeToFit];
     [self setValue:0.0 withAnimation:NO completion:nil];
 }
@@ -195,16 +196,16 @@ static float handleViewLeft = 0.0f;
     }
     
     self.value = p.x / self.frame.size.width;
-    self.foregroundView.frame = CGRectMake(0, kBorderWidth, p.x, self.frame.size.height);
+    self.foregroundView.frame = CGRectMake(0, 0, p.x, self.frame.size.height);
     
     if (self.foregroundView.frame.size.width <= 0) {
-        self.handleView.frame = CGRectMake(0, kBorderWidth, self.handleWidth, self.foregroundView.frame.size.height-kBorderWidth);
+        self.handleView.frame = CGRectMake(0, 0, self.handleWidth, self.foregroundView.frame.size.height);
         [self.delegate sliderValueChanged:self]; // or use sliderValueChangeEnded method
     }else if (self.foregroundView.frame.size.width >= self.frame.size.width) {
-        self.handleView.frame = CGRectMake(self.foregroundView.frame.size.width-self.handleWidth, kBorderWidth, self.handleWidth, self.foregroundView.frame.size.height-kBorderWidth*2);
+        self.handleView.frame = CGRectMake(self.foregroundView.frame.size.width-self.handleWidth, 0, self.handleWidth, self.foregroundView.frame.size.height);
         [self.delegate sliderValueChanged:self]; // or use sliderValueChangeEnded method
     }else{
-        self.handleView.frame = CGRectMake(self.foregroundView.frame.size.width-self.handleWidth/2, kBorderWidth, self.handleWidth, self.foregroundView.frame.size.height-kBorderWidth*2);
+        self.handleView.frame = CGRectMake(self.foregroundView.frame.size.width-self.handleWidth/2, 0, self.handleWidth, self.foregroundView.frame.size.height);
     }
     
 }


### PR DESCRIPTION
修改LPDSliderView继承UIControl,避免该控件接受业务中的其他交互，只单纯接受滑动操作，另外在layoutsubviews方法中改修改label的frame